### PR TITLE
Fix running errors

### DIFF
--- a/call_map/gui.py
+++ b/call_map/gui.py
@@ -408,7 +408,7 @@ class CallList(QtWidgets.QListWidget):
         for ii, node in enumerate(nodes):
             self.insertCallListItem(start + ii, node)
 
-    @QtCore.Slot(int, object)
+    @QtCore.pyqtSlot(int, object)
     def insertCallListItem(self, ii, node: Node):
         self.nodes_to_items[node] = CallListItem(node)
         self.insertItem(ii, CallListItem(node))

--- a/call_map/project_settings_module.py
+++ b/call_map/project_settings_module.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 import json
 import logging
-from typing import List, GenericMeta, Any, Tuple, Optional, Dict, Iterable
+from typing import List, Any, Tuple, Optional, Dict, Iterable
+try:
+    from typing import GenericMeta  # python 3.6
+except ImportError:
+    class GenericMeta(type): pass
 import toolz as tz
 
 from .core import UserScopeSettings, ScopeSettings, CodeElement, CallPosType, Node


### PR DESCRIPTION
### 1)
```
File ".../call_map/call_map/project_settings_module.py", line 4, in <module>
    from typing import List, GenericMeta, Any, Tuple, Optional, Dict, Iterable
ImportError: cannot import name 'GenericMeta' from 'typing' (/usr/lib/python3.9/typing.py)
```
https://github.com/hsolbrig/PyShEx/issues/17#issuecomment-427557545

### 2)
```
  File ".../call_map/call_map/gui.py", line 411, in CallList
    @QtCore.Slot(int, object)
AttributeError: module 'PyQt5.QtCore' has no attribute 'Slot'
```
https://stackoverflow.com/questions/50459672/attributeerror-module-pyqt5-qtcore-has-no-attribute-slot
https://www.riverbankcomputing.com/static/Docs/PyQt5/signals_slots.html#the-pyqtslot-decorator